### PR TITLE
Simplify the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
 FROM python:3.6.5-alpine3.7
-MAINTAINER Rémy Greinhofer <remy.greinhofer@gmail.com>
+MAINTAINER Rémy Greinhofer <remy.greinhofer@requestyoracks.org>
 
-# Install package.
+# Install packages.
 RUN pip install --no-cache-dir flower==0.9.2 redis==2.10.6
-
-# Copy entrypoint.
-COPY docker-entrypoint.sh /
 
 # Expose port.
 EXPOSE 5555
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
+# Set the entrypoint.
+ENTRYPOINT ["celery", "flower"]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TOPDIR = $(shell git rev-parse --show-toplevel)
 PROJECT_NAME = celery-flower
 
 # Docker.
-DOCKER_ORG = ryr
+DOCKER_ORG = requestyoracks
 DOCKER_IMAGE=$(PROJECT_NAME)
 TAG ?= $(shell git describe)
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,20 @@ RYR Docker image for Flower (A Real-time Celery web-monitor)
 
 Using the default broker:
 ```bash
-docker run -it --rm -p 5555:5555 ryr/celery-flower:0.9.2
+docker run -it --rm -p 5555:5555 requestyoracks/celery-flower:0.9.2
 ```
 
 Using a specific broker:
 ```bash
-docker run -it --rm -e "FLOWER_BROKER_URL=redis://192.168.99.100:30558/0" -p 5555:5555  ryr/celery-flower:0.9.2
+docker run -it --rm -e "FLOWER_BROKER_URL=redis://192.168.99.100:30558/0" -p 5555:5555  requestyoracks/celery-flower:0.9.2
 ```
+
+## Advanced configuration
+
+Configuration settings can be defined using environment variables. The full list of options can be found here: https://flower.readthedocs.io/en/stable/config.html.
+
+Prefix the Flower options by `FLOWER_` and the Celery ones by `CELERY` in order to use them.
+
+For instance:
+* `--basic_auth=user:password` becomes `FLOWER_BASIC_AUTH=user:password`.
+* `--broker=redis://guest:guest@localhost:6379/0` becomes `CELERY_BROKER_URL=redis://guest:guest@localhost:6379/0`

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Define default values.
-: ${FLOWER_BROKER_URL:="amqp://guest:guest@localhost:5672//"}
-
-# Launch Flower.
-exec celery flower --broker=$FLOWER_BROKER_URL


### PR DESCRIPTION
Simplifies the image by removing the unnecessary entrypoint.

The documentation was updated accordingly to explain how to configure
Flower using environment variables.